### PR TITLE
Fix variable in SpeedAccelM1M2_2  method

### DIFF
--- a/roboclaw_python/roboclaw_3.py
+++ b/roboclaw_python/roboclaw_3.py
@@ -846,7 +846,7 @@ class Roboclaw:
 		return (0,0,0)
 
 	def SpeedAccelM1M2_2(self,address,accel1,speed1,accel2,speed2):
-		return self._write4S44S4(address,self.Cmd.MIXEDSPEED2ACCEL,accel,speed1,accel2,speed2)
+		return self._write4S44S4(address,self.Cmd.MIXEDSPEED2ACCEL,accel1,speed1,accel2,speed2)
 
 	def SpeedAccelDistanceM1M2_2(self,address,accel1,speed1,distance1,accel2,speed2,distance2,buffer):
 		return self._write4S444S441(address,self.Cmd.MIXEDSPEED2ACCELDIST,accel1,speed1,distance1,accel2,speed2,distance2,buffer)


### PR DESCRIPTION
The name of the variable in the SpeedAccelM1M2_2 method is presently incorrect in the write, this will result in an exception being thrown when the method is called if not fixed. 