### PR TITLE
fix typo in robowclaw3

### DIFF
--- a/roboclaw_python/roboclaw_3.py
+++ b/roboclaw_python/roboclaw_3.py
@@ -846,7 +846,7 @@ class Roboclaw:
 		return (0,0,0)
 
 	def SpeedAccelM1M2_2(self,address,accel1,speed1,accel2,speed2):
-		return self._write4S44S4(address,self.Cmd.MIXEDSPEED2ACCEL,accel,speed1,accel2,speed2)
+		return self._write4S44S4(address,self.Cmd.MIXEDSPEED2ACCEL,accel1,speed1,accel2,speed2)
 
 	def SpeedAccelDistanceM1M2_2(self,address,accel1,speed1,distance1,accel2,speed2,distance2,buffer):
 		return self._write4S444S441(address,self.Cmd.MIXEDSPEED2ACCELDIST,accel1,speed1,distance1,accel2,speed2,distance2,buffer)


### PR DESCRIPTION
the SpeedAccelM1M2_2 function in the roboclaw3 file tries to use the variable named accel, but the parameter is called accel1. This rectifies that issue.

TLDR: changing it from accel to accel1 so its correct