### PR TITLE
Cast PID values to int in SetM1VelocityPID and SetM2VelocityPID

### DIFF
--- a/roboclaw_python/roboclaw_3.py
+++ b/roboclaw_python/roboclaw_3.py
@@ -758,11 +758,11 @@ class Roboclaw:
 
 	def SetM1VelocityPID(self,address,p,i,d,qpps):
 #		return self._write4444(address,self.Cmd.SETM1PID,long(d*65536),long(p*65536),long(i*65536),qpps)
-		return self._write4444(address,self.Cmd.SETM1PID,d*65536,p*65536,i*65536,qpps)
+		return self._write4444(address,self.Cmd.SETM1PID,int(d*65536),int(p*65536),int(i*65536),qpps)
 
 	def SetM2VelocityPID(self,address,p,i,d,qpps):
 #		return self._write4444(address,self.Cmd.SETM2PID,long(d*65536),long(p*65536),long(i*65536),qpps)
-		return self._write4444(address,self.Cmd.SETM2PID,d*65536,p*65536,i*65536,qpps)
+		return self._write4444(address,self.Cmd.SETM2PID,int(d*65536),int(p*65536),int(i*65536),qpps)
 
 	def ReadISpeedM1(self,address):
 		return self._read4_1(address,self.Cmd.GETM1ISPEED)


### PR DESCRIPTION
This allows passing of decimal values into SetM1VelocityPID and SetM2VelocityPID. Without this, one can only set PID values to be a multiple of 65536. Python raises a type error if you try to pass in a decimal.

Fixes: https://github.com/basicmicro/roboclaw_python_library/issues/1